### PR TITLE
fix: remove managed policies from cloned role

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -172,6 +172,8 @@ class ServerlessIamPerFunctionPlugin {
         },
       ],
     };
+    // remove managed policies
+    functionIamRole.Properties.ManagedPolicyArns = [];
     //set vpc if needed
     if (!_.isEmpty(functionObject.vpc) || !_.isEmpty(this.serverless.service.provider.vpc)) {
       functionIamRole.Properties.ManagedPolicyArns = [

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -128,6 +128,7 @@ describe('plugin tests', function(this: any) {
         const helloRole = serverless.service.provider.compiledCloudFormationTemplate.Resources.HelloIamRoleLambdaExecution;
         assert.isNotEmpty(helloRole);
         assertFunctionRoleName('hello', helloRole.Properties.RoleName);
+        assert.isEmpty(helloRole.Properties.ManagedPolicyArns, 'function resource role has no managed policy');
         //check depends and role is set properlly
         const helloFunctionResource = serverless.service.provider.compiledCloudFormationTemplate.Resources.HelloLambdaFunction;
         assert.isTrue(helloFunctionResource.DependsOn.indexOf('HelloIamRoleLambdaExecution') >= 0, 'function resource depends on role');


### PR DESCRIPTION
This PR fixes a bug with managed policies containing VPC execution role even when it's not needed.

As the function role is created from a clone of the global role, if the global role contains a managed VPC policy (it is the case if one or more functions have the vpc property in the service) and if the function doesn't have the vpc property it will still get the managed VPC policy.