### PR TITLE
remove lambdaRole from role name

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -53,6 +53,9 @@ class ServerlessIamPerFunctionPlugin {
     if(!_.isArray(fnJoin) || fnJoin.length !== 2 || !_.isArray(fnJoin[1]) || fnJoin[1].length < 2) {
       throw new this.serverless.classes.Error("Global Role Name is not in exepcted format. Got name: " + JSON.stringify(roleName));
     }
+    // Remove lambdaRole from name to give more space for function name.
+    fnJoin[1].pop();
+
     fnJoin[1].splice(2, 0, functionName);
     let length=0; //calculate the expected length. Sum the lenght of each part
     for (const part of fnJoin[1]) {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -45,7 +45,16 @@ class ServerlessIamPerFunctionPlugin {
       throw new this.serverless.classes.Error(`ERROR: could not find ${awsPackagePluginName} plugin to verify statements.`);      
     }
     this.awsPackagePlugin.validateStatements(statements);
-  } 
+  }
+  
+  getRoleNameLength(name_parts: any[]) {
+    let length=0; //calculate the expected length. Sum the length of each part
+    for (const part of name_parts) {
+      length += part.length;
+    }
+    length += (name_parts.length - 1); //take into account the dashes between parts
+    return length;
+  }
 
   getFunctionRoleName(functionName: string) {
     const roleName = this.serverless.providers.aws.naming.getRoleName();
@@ -53,16 +62,12 @@ class ServerlessIamPerFunctionPlugin {
     if(!_.isArray(fnJoin) || fnJoin.length !== 2 || !_.isArray(fnJoin[1]) || fnJoin[1].length < 2) {
       throw new this.serverless.classes.Error("Global Role Name is not in exepcted format. Got name: " + JSON.stringify(roleName));
     }
-    // Remove lambdaRole from name to give more space for function name.
-    fnJoin[1].pop();
-
-    fnJoin[1].splice(2, 0, functionName);
-    let length=0; //calculate the expected length. Sum the lenght of each part
-    for (const part of fnJoin[1]) {
-      length += part.length;
+    fnJoin[1].splice(2, 0, functionName); //insert the function name
+    if(this.getRoleNameLength(fnJoin[1]) > 64 && fnJoin[1][fnJoin[1].length-1] === 'lambdaRole') {
+      // Remove lambdaRole from name to give more space for function name.
+      fnJoin[1].pop();
     }
-    length += (fnJoin[1].length - 1); //take into account the dashes between parts
-    if(length > 64) { //aws limits to 64 chars the role name
+    if(this.getRoleNameLength(fnJoin[1]) > 64) { //aws limits to 64 chars the role name
       throw new this.serverless.classes.Error(`auto generated role name for function: ${functionName} is too long (over 64 chars).
         Try setting a custom role name using the property: iamRoleStatementsName.`);
     }

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -59,7 +59,7 @@ describe('plugin tests', function(this: any) {
   }
   
   describe('defaultInherit not set', () => {    
-    let plugin: any;
+    let plugin: Plugin;
     
     beforeEach(async () => {      
       plugin = new Plugin(serverless);
@@ -115,10 +115,24 @@ describe('plugin tests', function(this: any) {
         const name = 'test-name';
         const roleName = plugin.getFunctionRoleName(name);
         assertFunctionRoleName(name, roleName);
+        const name_parts = roleName['Fn::Join'][1];
+        assert.equal(name_parts[name_parts.length - 1], 'lambdaRole');        
       });
 
       it('should throw an error on long name', () => {
         assert.throws(() => {plugin.getFunctionRoleName('long-long-long-long-long-long-long-long-long-long-long-name');});
+      });
+
+      it('should return a name without "lambdaRole"', () => {
+        let name = 'test-name';        
+        let roleName = plugin.getFunctionRoleName(name);
+        const len = plugin.getRoleNameLength(roleName['Fn::Join'][1]);
+        //create a name which causes role name to be longer than 64 chars by 1. Will cause then lambdaRole to be removed
+        name += 'a'.repeat(64 - len + 1);
+        roleName = plugin.getFunctionRoleName(name);
+        assertFunctionRoleName(name, roleName);
+        const name_parts = roleName['Fn::Join'][1];
+        assert.notEqual(name_parts[name_parts.length - 1], 'lambdaRole');        
       });
     });
 


### PR DESCRIPTION
Provides more room for function name. Needed because of 64 char limit on
IAM role names.