### PR TITLE
Prevent hard code aws partition in arn of resources

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -190,7 +190,7 @@ class ServerlessIamPerFunctionPlugin {
       Action: ["logs:CreateLogStream", "logs:PutLogEvents"],
       Resource: [
         { 
-          'Fn::Sub': 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}' + 
+          'Fn::Sub': 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' + 
             `:log-group:${this.serverless.providers.aws.naming.getLogGroupName(functionObject.name)}:*:*`, 
         },
       ],
@@ -200,7 +200,7 @@ class ServerlessIamPerFunctionPlugin {
     //set vpc if needed
     if (!_.isEmpty(functionObject.vpc) || !_.isEmpty(this.serverless.service.provider.vpc)) {
       functionIamRole.Properties.ManagedPolicyArns = [
-        'arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole',
+        'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole',
       ];
     }    
     for (const s of this.getStreamStatements(functionObject)) { //set stream statements (if needed)

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -177,7 +177,7 @@ describe('plugin tests', function(this: any) {
         //verify helloEmptyIamStatements
         const helloEmptyIamStatementsRole = serverless.service.provider.compiledCloudFormationTemplate.Resources.HelloEmptyIamStatementsIamRoleLambdaExecution;
         assertFunctionRoleName('helloEmptyIamStatements', helloEmptyIamStatementsRole.Properties.RoleName);
-        assert.equal(helloEmptyIamStatementsRole.Properties.ManagedPolicyArns[0], 'arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole');
+        assert.equal(helloEmptyIamStatementsRole.Properties.ManagedPolicyArns[0], 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole');
         const helloEmptyFunctionResource = serverless.service.provider.compiledCloudFormationTemplate.Resources.HelloEmptyIamStatementsLambdaFunction;
         assert.isTrue(helloEmptyFunctionResource.DependsOn.indexOf('HelloEmptyIamStatementsIamRoleLambdaExecution') >= 0, 'function resource depends on role');
         assert.equal(helloEmptyFunctionResource.Properties.Role["Fn::GetAtt"][0], 'HelloEmptyIamStatementsIamRoleLambdaExecution', 
@@ -199,7 +199,7 @@ describe('plugin tests', function(this: any) {
       });
 
       it('should throw when external role is defined', () => {
-        _.set(serverless.service, "functions.hello.role", "arn:aws:iam::0123456789:role/Test");
+        _.set(serverless.service, "functions.hello.role", "arn:${AWS::Partition}:iam::0123456789:role/Test");
         assert.throws(() => {
           plugin.createRolesPerFunction();
         });


### PR DESCRIPTION
So far, there are 3 aws partitions as following: aws, aws-us-gov, aws-cn. Use ${AWS::Partition} to extend the flexibility.