### PR TITLE
Resolve AWS::Region reference in role name

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -66,7 +66,8 @@ class ServerlessIamPerFunctionPlugin {
     let length=0; //calculate the expected length. Sum the length of each part
     for (const part of name_parts) {
       if (part.Ref) {
-        length += part.Ref.length;
+        const ref = this.resolveRef(part.Ref)
+        length += ref.length;
       }
       else {
         length += part.length;
@@ -306,6 +307,20 @@ class ServerlessIamPerFunctionPlugin {
       this.createRoleForFunction(func, functionToRoleMap);
     }
     this.setEventSourceMappings(functionToRoleMap);
+  }
+
+  private getRegion(): string {
+    return this.serverless.service.provider.region
+  }
+
+  private resolveRef(ref: string): string {
+    switch (ref) {
+      case "AWS::Region":
+        return this.getRegion();
+      default:
+        // TODO: Is there a way to generically resolve the reference? Else maybe just throw an error?
+        return ref
+    }
   }
 }
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -65,14 +65,15 @@ class ServerlessIamPerFunctionPlugin {
   getRoleNameLength(name_parts: any[]) {
     let length=0; //calculate the expected length. Sum the length of each part
     for (const part of name_parts) {
-      if (part.Ref) {
-        const ref = this.resolveRef(part.Ref)
-        length += ref.length;
+      if (part.Ref === 'AWS::Region') {
+        length += this.getRegion().length;
+      }
+      else if (part.Ref) {
+        this.throwError(`ERROR: could not resolve ${part.Ref} reference in role name.`);
       }
       else {
         length += part.length;
       }
-      
     }
     length += (name_parts.length - 1); //take into account the dashes between parts
     return length;
@@ -311,16 +312,6 @@ class ServerlessIamPerFunctionPlugin {
 
   private getRegion(): string {
     return this.serverless.service.provider.region
-  }
-
-  private resolveRef(ref: string): string {
-    switch (ref) {
-      case "AWS::Region":
-        return this.getRegion();
-      default:
-        // TODO: Is there a way to generically resolve the reference? Else maybe just throw an error?
-        return ref
-    }
   }
 }
 


### PR DESCRIPTION
Resolves #26.

The name of the IAM role generated by the plugin consists of a few different parts, e.g.

```
[
  'aws-nodejs',
  'dev',
  'hello',
  { Ref: 'AWS::Region' },
  'lambdaRole'
]
```

When the IAM role name exceeds the 64 character limit, the plugin tries to shorten the role name by dropping the last "lambdaRole" part from the name. In determining the length of the role name, the plugin just uses the literal string `AWS::Region`. However, at deployment time, this reference will be resolved to the actual name of the AWS region, e.g. something like `ap-southeast-1`. The actual region name can be longer than the string `AWS::Region`, which can cause the role name to still exceed the 64 character limit.

This PR addresses this issue by trying to resolve the region reference in the name, when determining the role name length.

One open question is, whether any other kinds of references might appear in the role name, and if yes, how to resolve those references. Maybe that's not the case in practice and we can just raise an error if we encounter an unexpected ref?