### PR TITLE
Use resolved region name in counting length of role name

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -66,9 +66,12 @@ class ServerlessIamPerFunctionPlugin {
     let length=0; //calculate the expected length. Sum the length of each part
     for (const part of name_parts) {
       if (part.Ref) {
-        length += this.serverless.service.provider.region.length
-      }
-      else {
+        if (part.Ref === 'AWS::Region') {
+          length += this.serverless.service.provider.region.length;
+        } else {
+          length += part.Ref.length;
+        }
+      } else {
         length += part.length;
       }
     }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -66,12 +66,11 @@ class ServerlessIamPerFunctionPlugin {
     let length=0; //calculate the expected length. Sum the length of each part
     for (const part of name_parts) {
       if (part.Ref) {
-        length += part.Ref.length;
+        length += this.serverless.service.provider.region.length
       }
       else {
         length += part.length;
       }
-      
     }
     length += (name_parts.length - 1); //take into account the dashes between parts
     return length;

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -125,6 +125,38 @@ describe('plugin tests', function(this: any) {
         });
       });
     });
+
+    describe('#getRoleNameLength', () => {
+      it('Should calculate the acurate role name length us-east-1', () => {
+        serverless.service.provider.region = 'us-east-1';
+        let function_name = 'a'.repeat(10);
+        let name_parts = [
+          serverless.service.service,         // test-service , length of 12
+          serverless.service.provider.stage,  // dev, length of 3 : 15
+          { Ref: 'AWS::Region' },             // us-east-1, length 9 : 24
+          function_name,                      // 'a'.repeat(10), length 10 : 34
+          'lambdaRole'                        // lambdaRole, length 10 : 44
+        ];
+        let role_name_length = plugin.getRoleNameLength(name_parts)
+        let expected = 44 // 12 + 3 + 9 + 10 + 10 == 44
+        assert.equal(role_name_length, expected + name_parts.length - 1);
+      });
+
+      it('Should calculate the acurate role name length ap-northeast-1', () => {
+        serverless.service.provider.region = 'ap-northeast-1';
+        let function_name = 'a'.repeat(10);
+        let name_parts = [
+          serverless.service.service,         // test-service , length of 12
+          serverless.service.provider.stage,  // dev, length of 3
+          { Ref: 'AWS::Region' },             // ap-northeast-1, length 14
+          function_name,                      // 'a'.repeat(10), length 10
+          'lambdaRole'                        // lambdaRole, length 10
+        ];
+        let role_name_length = plugin.getRoleNameLength(name_parts)
+        let expected = 49 // 12 + 3 + 14 + 10 + 10 == 49
+        assert.equal(role_name_length, expected + name_parts.length - 1);
+      });
+    });
     
     describe('#getFunctionRoleName', () => {
       it('should return a name with the function name', () => {

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -156,6 +156,21 @@ describe('plugin tests', function(this: any) {
         let expected = 49 // 12 + 3 + 14 + 10 + 10 == 49
         assert.equal(role_name_length, expected + name_parts.length - 1);
       });
+
+      it('Should calculate the actual length for a non AWS::Region ref to maintain backward compatability', () => {
+        serverless.service.provider.region = 'ap-northeast-1';
+        let function_name = 'a'.repeat(10);
+        let name_parts = [
+          serverless.service.service,         // test-service , length of 12
+          { Ref: 'bananas'},                  // bananas, length of 7
+          { Ref: 'AWS::Region' },             // ap-northeast-1, length 14
+          function_name,                      // 'a'.repeat(10), length 10
+          'lambdaRole'                        // lambdaRole, length 10
+        ];
+        let role_name_length = plugin.getRoleNameLength(name_parts)
+        let expected = 53 // 12 + 7 + 14 + 10 + 10 == 53
+        assert.equal(role_name_length, expected + name_parts.length - 1);
+      });
     });
     
     describe('#getFunctionRoleName', () => {


### PR DESCRIPTION
Fixes #26. 

Added tests that will fail if the region is _not_ accounted for in [getRoleNameLength()](https://github.com/functionalone/serverless-iam-roles-per-function/blob/master/src/lib/index.ts#L65).