### PR TITLE
Add support for custom role names

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ The plugin uses a naming convention for function roles which is similar to the n
 ```
 <service-name>-<stage>-<function-name>-<region>-lambdaRole
 ```
+You can specify a custom role name:
+```yml
+custom:
+  serverless-iam-roles-per-function:
+    customRoleName: true # defaults to false
+    roleNamePrefix: prefix # required if `customRoleName` is `true`
+    roleNameSuffix: suffix # optional
+```
 AWS has a 64 character limit on role names. If the default naming exceeds 64 chars the plugin will remove the suffix: `-lambdaRole` to shorten the name. If it still exceeds 64 chars an error will be thrown containing a message of the form:
 ```
 auto generated role name for function: ${functionName} is too long (over 64 chars).

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -356,4 +356,37 @@ describe('plugin tests', function(this: any) {
     });    
   });
 
+  describe('custom role names set', () => {    
+    let plugin: Plugin;
+
+    beforeEach(() => {      
+      //set customRoleName
+      _.set(serverless.service, "custom.serverless-iam-roles-per-function.customRoleName", true);
+      //set roleNamePrefix
+      _.set(serverless.service, "custom.serverless-iam-roles-per-function.roleNamePrefix", "prefix");
+      _.set(serverless.service, "custom.serverless-iam-roles-per-function.roleNameSuffix", "suffix");
+      plugin = new Plugin(serverless);
+    });
+
+    describe('#constructor()', () => {      
+      it('custom role names properly set', () => {
+        assert.isTrue(plugin.customRoleName);
+        assert.equal(plugin.roleNamePrefix, "prefix");
+        assert.equal(plugin.roleNameSuffix, "suffix");
+      });
+    });
+
+    describe('#createRolesPerFunction', () => {
+      it('should create role per function', () => {
+        plugin.createRolesPerFunction();
+        const helloRole = serverless.service.provider.compiledCloudFormationTemplate.Resources.HelloIamRoleLambdaExecution;
+        assert.isNotEmpty(helloRole);
+        assertFunctionRoleName('hello', helloRole.Properties.RoleName);
+        assert.equal(helloRole.Properties.RoleName['Fn::Join'][1][0], "prefix");
+        assert.equal(helloRole.Properties.RoleName['Fn::Join'][1][1], "hello");
+        assert.equal(helloRole.Properties.RoleName['Fn::Join'][1][2], "suffix");
+      });
+    });    
+  });
+
 });


### PR DESCRIPTION
You can now specify custom role names.

```yml
custom:
  serverless-iam-roles-per-function:
    customRoleName: true # defaults to false
    roleNamePrefix: prefix # required if `customRoleName` is true
    roleNameSuffix: suffix # optional
```