### PR TITLE
feat: Support new provider.iam property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [3.2.0](https://github.com/functionalone/serverless-iam-roles-per-function/compare/v3.1.1...v3.2.0) (2021-03-19)
+
+
+### Features
+
+* Support new provider.iam property ([0d3dd37](https://github.com/functionalone/serverless-iam-roles-per-function/commit/0d3dd37328b283cafc92f42dbc16ed37a6ecd7b2)), closes [#73](https://github.com/functionalone/serverless-iam-roles-per-function/issues/73)
+
 ### [3.1.1](https://github.com/functionalone/serverless-iam-roles-per-function/compare/v3.1.0...v3.1.1) (2021-01-03)
 
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,31 @@ functions:
 
 By default, function level `iamRoleStatements` override the provider level definition. It is also possible to inherit the provider level definition by specifying the option `iamRoleStatementsInherit: true`:
 
+**serverless >= v2.24.0**
+```yaml
+provider:
+  name: aws
+  iam:
+    role:
+      statements:
+        - Effect: "Allow"
+          Action:
+            - xray:PutTelemetryRecords
+            - xray:PutTraceSegments
+          Resource: "*"
+  ...
+functions:
+  func1:
+    handler: handler.get
+    iamRoleStatementsInherit: true
+    iamRoleStatements:
+      - Effect: "Allow"        
+        Action:
+          - dynamodb:GetItem        
+        Resource: "arn:aws:dynamodb:${self:provider.region}:*:table/mytable"
+```
+
+**serverless < v2.24.0**
 ```yaml
 provider:
   name: aws
@@ -92,6 +117,7 @@ functions:
           - dynamodb:GetItem        
         Resource: "arn:aws:dynamodb:${self:provider.region}:*:table/mytable"
 ```
+
 The generated role for `func1` will contain both the statements defined at the provider level and the ones defined at the function level.
 
 If you wish to change the default behavior to `inherit` instead of `override` it is possible to specify the following custom configuration:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-iam-roles-per-function",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "serverless-iam-roles-per-function",
   "private": false,
-  "version": "3.1.1",
+  "version": "3.2.0",
   "engines": {
     "node": ">=10"
   },

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -344,8 +344,15 @@ class ServerlessIamPerFunctionPlugin {
     const isInherit = functionObject.iamRoleStatementsInherit
       || (this.defaultInherit && functionObject.iamRoleStatementsInherit !== false);
 
-    if (isInherit && !_.isEmpty(this.serverless.service.provider.iamRoleStatements)) { // add global statements
-      for (const s of this.serverless.service.provider.iamRoleStatements) {
+    // Since serverless 2.24.0 provider.iamRoleStatements is deprecated
+    // https://github.com/serverless/serverless/blob/master/CHANGELOG.md#2240-2021-02-16
+    // Support old & new iam statements by checking if `iam` property exists
+    const providerIamRoleStatements = this.serverless.service.provider.iam
+      ? this.serverless.service.provider.iam.role?.statements
+      : this.serverless.service.provider.iamRoleStatements;
+
+    if (isInherit && !_.isEmpty(providerIamRoleStatements)) { // add global statements
+      for (const s of providerIamRoleStatements) {
         policyStatements.push(s);
       }
     }

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -34,7 +34,7 @@ describe('plugin tests', function(this: any) {
   beforeEach(async () => {
     serverless = new Serverless();
     serverless.cli = new serverless.classes.CLI();
-    
+
     // Since serverless 2.24.0 processInput function doesn't exists
     if (serverless.cli.processInput) {
       serverless.processedInput = serverless.cli.processInput();

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -34,7 +34,12 @@ describe('plugin tests', function(this: any) {
   beforeEach(async () => {
     serverless = new Serverless();
     serverless.cli = new serverless.classes.CLI();
-    serverless.processedInput = serverless.cli.processInput();
+    
+    // Since serverless 2.24.0 processInput function doesn't exists
+    if (serverless.cli.processInput) {
+      serverless.processedInput = serverless.cli.processInput();
+    }
+
     Object.assign(serverless.service, _.cloneDeep(funcWithIamTemplate));
     serverless.service.provider.compiledCloudFormationTemplate = {
       Resources: {},

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -35,7 +35,7 @@ describe('plugin tests', function(this: any) {
     serverless = new Serverless();
     serverless.cli = new serverless.classes.CLI();
 
-    // Since serverless 2.24.0 processInput function doesn't exists
+    // Since serverless 2.24.0 processInput function doesn't exist
     if (serverless.cli.processInput) {
       serverless.processedInput = serverless.cli.processInput();
     }

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -445,12 +445,12 @@ describe('plugin tests', function(this: any) {
     const getLambdaTestStatements = (): any[] => {
       const plugin = new Plugin(serverless);
 
-        const compiledResources = serverless.service.provider.compiledCloudFormationTemplate.Resources;
-        plugin.createRolesPerFunction();
-        const helloInherit = compiledResources.HelloInheritIamRoleLambdaExecution;
-        assert.isNotEmpty(helloInherit);
+      const compiledResources = serverless.service.provider.compiledCloudFormationTemplate.Resources;
+      plugin.createRolesPerFunction();
+      const helloInherit = compiledResources.HelloInheritIamRoleLambdaExecution;
+      assert.isNotEmpty(helloInherit);
 
-        return helloInherit.Properties.Policies[0].PolicyDocument.Statement;
+      return helloInherit.Properties.Policies[0].PolicyDocument.Statement;
     }
 
     it('no global iam and iamRoleStatements properties', () => {
@@ -483,7 +483,7 @@ describe('plugin tests', function(this: any) {
 
       it('no role property', () => {
         _.set(serverless.service, 'provider.iam', {
-          deploymentRole: 'arn:aws:iam::123456789012:role/deploy-role'
+          deploymentRole: 'arn:aws:iam::123456789012:role/deploy-role',
         });
 
         const statements = getLambdaTestStatements();
@@ -498,7 +498,7 @@ describe('plugin tests', function(this: any) {
 
       it('role property set to role ARN', () => {
         _.set(serverless.service, 'provider.iam', {
-          role: 'arn:aws:iam::0123456789:role//my/default/path/roleInMyAccount'
+          role: 'arn:aws:iam::0123456789:role//my/default/path/roleInMyAccount',
         });
 
         const statements = getLambdaTestStatements();
@@ -514,8 +514,8 @@ describe('plugin tests', function(this: any) {
       it('role is set without statements', () => {
         _.set(serverless.service, 'provider.iam', {
           role: {
-            managedPolicies: ['arn:aws:iam::123456789012:user/*']
-          }
+            managedPolicies: ['arn:aws:iam::123456789012:user/*'],
+          },
         });
 
         const statements = getLambdaTestStatements();
@@ -531,8 +531,8 @@ describe('plugin tests', function(this: any) {
       it('empty statements', () => {
         _.set(serverless.service, 'provider.iam', {
           role: {
-            statements: []
-          }
+            statements: [],
+          },
         });
 
         const statements = getLambdaTestStatements();
@@ -545,18 +545,18 @@ describe('plugin tests', function(this: any) {
         );
       });
     });
- 
+
     it('global iam role statements exists in lambda role statements', () => {
       _.set(serverless.service, 'provider.iam', {
         role: {
           statements: [{
             Effect: 'Allow',
             Action: [
-              'ec2:CreateNetworkInterface'
+              'ec2:CreateNetworkInterface',
             ],
-            Resource: '*'
-          }]
-        }
+            Resource: '*',
+          }],
+        },
       });
 
       const statements = getLambdaTestStatements();


### PR DESCRIPTION
Support the new `provider.iam` property (serverless >= [v2.4.0](https://github.com/serverless/serverless/blob/master/CHANGELOG.md#2240-2021-02-16))

Closes #73 

