### PR TITLE
Register `serverless` as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
     "ts-node": "^9.0.0",
     "typescript": "^4.1.2"
   },
+  "peerDependencies": {
+    "serverless": "1 || 2 || 3"
+  },
   "files": [
     "dist/index.*",
     "dist/lib/**",


### PR DESCRIPTION
It's to ensure only compatible versions or Framework are used together with a plugin, and if mismatch occurs, user is informed with meaningful error message.

_This PR is part of Serverless Framework initiative to [curate most popular plugins](https://github.com/serverless/serverless/issues/9025)_

