### PR TITLE
ci: added github workflow build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: Build
+on: [pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ '12', '14', '16' ]
+        serverless-version: ['latest', 'latest~1', 'latest~2']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+      - run: npm install
+      - run: npm install --no-save --ignore-scripts `npx npm-get-version serverless@$SERVERLESS_VERSION`
+        env:
+          SERVERLESS_VERSION: ${{ matrix.serverless-version }}
+      - run: npm run lint
+      - run: npm test
+
+      - name: Coveralls Parallel
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          flag-name: run-${{ matrix.node }}
+          # This is a parallel build so need this
+          parallel: true
+
+# As testing against multiple versions need this to
+  # finish the parallel build
+  finish:
+    name: Coveralls coverage
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          parallel-finished: true

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "test-bare": "npm run compile && mocha ./dist/test/**/*.test.js",
-    "test": "nyc mocha --require ts-node/register --require source-map-support/register  ./src/test/**/*.test.ts",
+    "test": "nyc --reporter=lcovonly mocha --require ts-node/register --require source-map-support/register  ./src/test/**/*.test.ts",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "compile": "tsc",
     "watch": "tsc -w",


### PR DESCRIPTION
Seeing as we don't perform any more builds using Travis this is the drop in replacement, for at least integration builds, using Github Actions. I believe this is need amongst other things.

Here you can see them in action:
https://github.com/andersquist/serverless-iam-roles-per-function/actions/runs/1363746287

It currently fails because the latest version of `serverless` has some breaking changes.