### PR TITLE
Support for Customer Managed Policies

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -326,6 +326,8 @@ class ServerlessIamPerFunctionPlugin {
     const functionIamRole = _.cloneDeep(globalIamRole);
     // remove the statements
     const policyStatements: Statement[] = [];
+    const defaultRolePolicy = functionIamRole.Properties.Policies[0];
+    // clean policies
     functionIamRole.Properties.Policies = [];
     // set log statements
     policyStatements[0] = {
@@ -423,7 +425,8 @@ class ServerlessIamPerFunctionPlugin {
         policyStatements,
       );
     } else {
-      functionIamRole.Properties.Policies[0].PolicyDocument.Statement = policyStatements;
+      defaultRolePolicy.PolicyDocument.Statement = policyStatements;
+      functionIamRole.Properties.Policies.push(defaultRolePolicy);
     }
   }
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -278,7 +278,8 @@ class ServerlessIamPerFunctionPlugin {
    * @return array of statements (possibly empty)
    */
   createCustomerManagedPolicy(functionName: string, roleName: string, template: any, policyStatements: Statement[]) {
-    const managedPolicyName = `${functionName}-${this.serverless.service.provider.region}-policy`;
+    const stackName = this.serverless.providers.aws.naming.getStackName();
+    const managedPolicyName = `${stackName}-${functionName}-${this.serverless.service.provider.region}-policy`;
 
     const managedPolicy = {
       'Type': 'AWS::IAM::ManagedPolicy',

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -292,7 +292,7 @@ class ServerlessIamPerFunctionPlugin {
    * @param {*} roleName
    * @param {*} template
    * @param {*} policyStatements
-   * @return array of statements (possibly empty)
+   * @returns void
    */
   createCustomerManagedPolicy(functionName: string, roleName: string, template: any, policyStatements: Statement[]) {
     const stackName = this.serverless.providers.aws.naming.getStackName();

--- a/src/test/funcs-with-iam.json
+++ b/src/test/funcs-with-iam.json
@@ -116,6 +116,23 @@
       "events": [],
       "name": "test-permissions-boundary-hello",
       "package": {}
+    },
+    "helloCustomerManagedPolicy": {
+      "handler": "handler.hello",
+      "iamRoleCreateCustomerManagedPolicy": true,
+      "iamRoleStatements": [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "dynamodb:GetItem"
+          ],
+          "Resource": "arn:aws:dynamodb:us-east-1:*:table/test"
+        }
+      ],
+      "events": [],
+      "name": "test-python-dev-hello-customer-managed-policy",
+      "package": {},
+      "vpc": {}
     }
   },
   "resources": {

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -453,7 +453,7 @@ describe('plugin tests', function(this: any) {
 
         console.log('helloCustomerManagedPolicyCustomerManagedPolicy', JSON.stringify(helloCustomerManagedPolicyCustomerManagedPolicy, null, 2));
         const managedPolicyName = helloCustomerManagedPolicyCustomerManagedPolicy.Properties.ManagedPolicyName;
-        assert.equal(managedPolicyName, 'helloCustomerManagedPolicy-us-east-1-policy');
+        assert.equal(managedPolicyName, 'test-service-dev-helloCustomerManagedPolicy-us-east-1-policy');
 
         const policyDocument = helloCustomerManagedPolicyCustomerManagedPolicy.Properties.PolicyDocument;
         assert.equal(policyDocument.Version, '2012-10-17');

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -443,6 +443,25 @@ describe('plugin tests', function(this: any) {
         const policyName = defaultIamRoleLambdaExecution.Properties.PermissionsBoundary['Fn::Sub'];
         assert.equal(policyName, 'arn:aws:iam::xxxxx:policy/permissions_boundary');
       })
+
+      it('should add policy document to a Customer Managed Policy', () => {
+        const compiledResources = serverless.service.provider.compiledCloudFormationTemplate.Resources;
+
+        plugin.createRolesPerFunction();
+
+        const helloCustomerManagedPolicyCustomerManagedPolicy = compiledResources.HelloCustomerManagedPolicyCustomerManagedPolicy;
+
+        console.log('helloCustomerManagedPolicyCustomerManagedPolicy', JSON.stringify(helloCustomerManagedPolicyCustomerManagedPolicy, null, 2));
+        const managedPolicyName = helloCustomerManagedPolicyCustomerManagedPolicy.Properties.ManagedPolicyName;
+        assert.equal(managedPolicyName, 'helloCustomerManagedPolicy-us-east-1-policy');
+
+        const policyDocument = helloCustomerManagedPolicyCustomerManagedPolicy.Properties.PolicyDocument;
+        assert.equal(policyDocument.Version, '2012-10-17');
+        assert.lengthOf(policyDocument.Statement, 3);
+
+        const roles = helloCustomerManagedPolicyCustomerManagedPolicy.Properties.Roles;
+        assert.equal(roles[0].Ref, 'HelloCustomerManagedPolicyIamRoleLambdaExecution');
+      })
     });
   });
 

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -455,7 +455,8 @@ describe('plugin tests', function(this: any) {
 
         plugin.createRolesPerFunction();
 
-        const helloCustomerManagedPolicyCustomerManagedPolicy = compiledResources.HelloCustomerManagedPolicyCustomerManagedPolicy;
+        const helloCustomerManagedPolicyCustomerManagedPolicy =
+          compiledResources.HelloCustomerManagedPolicyCustomerManagedPolicy;
 
         const managedPolicyName = helloCustomerManagedPolicyCustomerManagedPolicy.Properties.ManagedPolicyName;
         assert.equal(managedPolicyName, 'test-service-dev-helloCustomerManagedPolicy-us-east-1-policy');


### PR DESCRIPTION
This is an attempt to include this functionality into the [serverless-iam-roles-per-function](https://github.com/functionalone/serverless-iam-roles-per-function) repository as it's one of my favorite plugins for my Serverless projects.

I have recently come across this issue where I need to have a project meet some criteria to be compliant with a security check. I have surfaced the web and I didn't find any solution to update the IAM roles created in my Serverless project to use Customer Managed Policy instead of an inline policy.

This was discussed in the [Serverless Forum](https://forum.serverless.com/t/is-it-possible-to-replace-inline-policy-with-customer-managed/18810) last year, but no solution was found.

My implementation exposes a property at the serverless template level, and for each individual lambda. If someone wants to create CustomerManagedPolicies for a single lambda, they can set the `defaultCreateCustomerManagedPolicy: true` in the specific lambda. Or if they want to have all their lambdas use the managed policy, they can add the property `custom.serverless-iam-roles-per-function.defaultCreateCustomerManagedPolicy: true` to the serverless template file.